### PR TITLE
csm-utils: Update debug path and add DDR file check

### DIFF
--- a/csm-configure-ip.sh
+++ b/csm-configure-ip.sh
@@ -64,7 +64,7 @@ configure_ipaddress() {
     interval=0.2 # seconds
     elapsed=0
 
-    debug_node="/sys/bus/mhi/devices/mhi$1_CSM_CTRL/debug_transport"
+    debug_node="/sys/bus/mhi/devices/mhi$1_CSM_CTRL/transport_mode"
     while (( $(echo "$elapsed < $timeout" | bc -l) )); do
         if [ -f "$debug_node" ]; then
                 echo "$debug_transport" > "$debug_node"

--- a/csm-store-ddr.sh
+++ b/csm-store-ddr.sh
@@ -19,6 +19,12 @@ ddr_training_to_firmware_system() {
     # Path for output file name
     OUTPUT_FILE=$LASSEN_DEVICE_FOLDER/mdmddr_${serialno}.mbn
 
+    # Check if serial number specific file exists.
+    if [ -f "$OUTPUT_FILE" ]; then
+	    echo "Training data  file exists: $OUTPUT_FILE"
+	    exit 1
+    fi
+
     # Create target directory if it doesn't exist
     mkdir -p "$LASSEN_DEVICE_FOLDER"
 


### PR DESCRIPTION
- Replaced `debug_transport` path with `transport_mode` in `csm-configure-ip.sh`
- Added check in `csm-store-ddr.sh` to prevent overwriting existing DDR training files