### PR TITLE
feat(csm-utils): add csm-event-handler.sh to manage CSM services via …

### DIFF
--- a/99-csm-device-remove.rules
+++ b/99-csm-device-remove.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="mhi", ACTION=="remove", KERNEL=="mhi[0-9]*_CSM_CTRL", RUN+="/etc/csm-nbdkit-stop.sh %k"
+SUBSYSTEM=="mhi", ACTION=="remove", KERNEL=="mhi[0-9]*_CSM_CTRL", RUN+="/usr/bin/csm-nbdkit-stop.sh %k"

--- a/99-mhi-csm-ctrl-device.rules
+++ b/99-mhi-csm-ctrl-device.rules
@@ -1,2 +1,3 @@
-SUBSYSTEM=="mhi", ACTION=="add", KERNEL=="mhi[0-9]*_CSM_CTRL", TAG+="systemd", ENV{SYSTEMD_WANTS}+="csm-nbdkit@%k.service csm-configure-ip@%k.service"
+SUBSYSTEM=="mhi", ACTION=="add", KERNEL=="mhi[0-9]*_SAHARA", RUN+="/usr/bin/csm-event-handler.sh %k"
+SUBSYSTEM=="mhi", ACTION=="add", KERNEL=="mhi[0-9]*_CSM_CTRL", RUN+="/usr/bin/csm-event-handler.sh %k"
 SUBSYSTEM=="mhi", ACTION=="add", KERNEL=="mhi[0-9]", TAG+="systemd", ENV{SYSTEMD_WANTS}+="csm-store-ddr@%k.service"

--- a/csm-configure-ip.sh
+++ b/csm-configure-ip.sh
@@ -49,34 +49,6 @@ configure_ipaddress() {
     MPLANE_ADDR="192.200.103.$1"
     echo "configure interface $MPLANE_INTERFACE $OAM_HOST_ADDR $MPLANE_ADDR"
     config_interface $MPLANE_INTERFACE $OAM_HOST_ADDR $MPLANE_ADDR
-
-    # get debug transport config
-    decimal_serial=$(cat /sys/bus/mhi/devices/mhi$1/serial_number | cut -d " " -f3)
-    serialno=$(convert_serial_to_hex "$decimal_serial")
-    LASSEN_DEVICE_FOLDER=/lib/firmware/qcom/qdu100/$serialno
-    if [ -f $LASSEN_DEVICE_FOLDER/debug_transport.conf ]; then
-        debug_transport=$(cat $LASSEN_DEVICE_FOLDER/debug_transport.conf)
-    else
-        debug_transport="pcie"
-    fi
-
-    timeout=10   # seconds
-    interval=0.2 # seconds
-    elapsed=0
-
-    debug_node="/sys/bus/mhi/devices/mhi$1_CSM_CTRL/transport_mode"
-    while (( $(echo "$elapsed < $timeout" | bc -l) )); do
-        if [ -f "$debug_node" ]; then
-                echo "$debug_transport" > "$debug_node"
-                echo "Copied $debug_transport to $debug_node"
-                return 0
-        fi
-        sleep $interval
-        elapsed=$(echo "$elapsed + $interval" | bc)
-    done
-
-    echo "Destination file $debug_node not found after $timeout seconds."
-    return 1
 }
 
 # Udev rule triggers csm_nbdkit service with SAHARA channel as argument when Device detected on PCIe channel at boot

--- a/csm-configure-ip@.service
+++ b/csm-configure-ip@.service
@@ -5,7 +5,7 @@
 
 [Unit]
 Description=Run csm configure IP service
-After=network.target
+After=network.target csm-nbdkit@.service
 Requires=network.target network-online.target remote-fs.target csm-nbdkit@.service
 
 [Service]

--- a/csm-event-handler.sh
+++ b/csm-event-handler.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#******************************************************************************
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#******************************************************************************/
+
+DEVICE="$1"
+echo "csm-event: starting script csm-event-handler" > /dev/kmsg
+
+if [[ "$DEVICE" == *"SAHARA"* ]]; then
+    echo "csm-event: $DEVICE: starting csm-nbdkit service for SAHARA" > /dev/kmsg
+    systemd-run --no-block systemctl restart csm-nbdkit@"$DEVICE".service &
+    echo "csm-event: $DEVICE: csm-nbdkit service completed with status:$?" > /dev/kmsg
+else
+    echo "csm-event: $DEVICE: starting csm-configure-ip service for CSM_CTRL" > /dev/kmsg
+    systemd-run --no-block systemctl restart csm-configure-ip@"$DEVICE".service &
+    echo "csm-event: $DEVICE: csm-configure-ip service completed with status:$?" > /dev/kmsg
+fi

--- a/rpm/csm-utils.spec
+++ b/rpm/csm-utils.spec
@@ -32,6 +32,7 @@ install -m 755 csm-utils/decimal-to-hex.sh $RPM_BUILD_ROOT%{_bindir}/decimal-to-
 install -m 644 csm-utils/99-mhi-csm-ctrl-device.rules $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d
 install -m 644 csm-utils/99-csm-device-remove.rules $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d
 install -m 755 csm-utils/csm-check-repair.sh $RPM_BUILD_ROOT%{_bindir}/csm-check-repair.sh
+install -m 755 csm-utils/csm-event-handler.sh $RPM_BUILD_ROOT%{_bindir}/csm-event-handler.sh
 
 %clean
 %{__rm} -rf $RPM_BUILD_ROOT
@@ -41,6 +42,7 @@ install -m 755 csm-utils/csm-check-repair.sh $RPM_BUILD_ROOT%{_bindir}/csm-check
 %{_bindir}/csm-nbdkit-stop.sh
 %{_bindir}/csm-configure-ip.sh
 %{_bindir}/csm-check-repair.sh
+%{_bindir}/csm-event-handler.sh
 %{_bindir}/csm-store-ddr.sh
 %{_bindir}/decimal-to-hex.sh
 %{_sysconfdir}/systemd/system/csm-nbdkit@.service


### PR DESCRIPTION
…uevents

Introduced csm-event-handler.sh script to start or restart CSM services based on uevents. This enhances automated service management triggered by system uevents.